### PR TITLE
Ruby 2 Fix

### DIFF
--- a/heroku.gemspec
+++ b/heroku.gemspec
@@ -18,10 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "git"
+  spec.add_dependency "git", "~> 1.2"
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "codeclimate-test-reporter"
+  spec.add_development_dependency "rake", "~> 10.3"
+  spec.add_development_dependency "rspec", "~> 3"
 end

--- a/lib/heroku/conn.rb
+++ b/lib/heroku/conn.rb
@@ -90,19 +90,21 @@ module Heroku
     end
 
     def self.parse_body(res)
-      JSON.parse(
-        case res["content-encoding"]
-        when 'gzip'
-          Zlib::GzipReader.new(
-            StringIO.new(res.body),
-            encoding: "ASCII-8BIT"
-          ).read
-        when 'deflate'
-          Zlib::Inflate.inflate(res.body)
-        else
-          res.body
-        end
-      )
+      JSON.parse(decompress(res))
+    end
+
+    def self.decompress(res)
+      case res["content-encoding"]
+      when 'gzip'
+        Zlib::GzipReader.new(
+          StringIO.new(res.body),
+          encoding: "ASCII-8BIT"
+        ).read
+      when 'deflate'
+        Zlib::Inflate.inflate(res.body)
+      else
+        res.body
+      end
     end
   end
 end

--- a/spec/heroku/conn_spec.rb
+++ b/spec/heroku/conn_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Heroku::Conn do
-
   describe ".check_response" do
     context "when the response is unsuccessful" do
       let(:unsuccessful_response) { Net::HTTPClientError.new() }
@@ -9,6 +8,58 @@ describe Heroku::Conn do
       it "should raise a error" do
         expect { described_class.send(:check_response, nil, nil, response) }.to raise_error
       end
+    end
+  end
+
+  describe ".parse_body" do
+    let(:hash) { {"lorem" => "ipsum dolor sit amet"} }
+    let(:body) { hash.to_json }
+    let(:res)  { double(:res) }
+
+    def self.it_returns_the_hash
+      it "returns the hash" do
+        expect(described_class.send(:parse_body, res)).to eq(hash)
+      end
+    end
+
+    def set_body(res, body)
+      allow(res).to receive(:body).and_return(body)
+    end
+
+    def set_encoding(res, enc)
+      allow(res).to receive(:[])
+        .with("content-encoding")
+        .and_return(enc)
+    end
+
+    context "when the body is not encoded" do
+      before do
+        set_encoding(res, "identity")
+        set_body(res, body)
+      end
+
+      it_returns_the_hash
+    end
+
+    context "when the body is deflated" do
+      before do
+        set_encoding(res, "deflate")
+        set_body(res, Zlib::Deflate.deflate(body))
+      end
+
+      it_returns_the_hash
+    end
+
+    context "when the body is gzipped" do
+      before do
+        set_encoding(res, "gzip")
+
+        strio = StringIO.new
+        Zlib::GzipWriter.wrap(strio) { |gz| gz.write(body) }
+        set_body(res, strio.string)
+      end
+
+      it_returns_the_hash
     end
   end
 end

--- a/spec/heroku/model/model_helper_spec.rb
+++ b/spec/heroku/model/model_helper_spec.rb
@@ -53,18 +53,33 @@ describe Heroku::Model::ModelHelper do
 
   describe "#identifier" do
     context "when there are no identifiable parameters" do
-      before { subject.should_receive(:identifiable).and_return({}) }
-      its(:identifier) { should == "" }
+      before do
+        expect(subject).to receive(:identifiable).and_return({})
+      end
+
+      it "should return an empty identifier" do
+        expect(subject.identifier).to be_empty
+      end
     end
 
     context "when the identifier is one parameter" do
-      before { subject.should_receive(:identifiable).and_return({ a: 1 }) }
-      its(:identifier) { should == "a=1" }
+      before do
+        expect(subject).to receive(:identifiable).and_return({ a: 1 })
+      end
+
+      it "should appear in the identifier" do
+        expect(subject.identifier).to eq "a=1"
+      end
     end
 
     context "when the identifier contains multiple parameters" do
-      before { subject.should_receive(:identifiable).and_return({ a: 1, b: 2}) }
-      its(:identifier) { should == "a=1, b=2" }
+      before do
+        expect(subject).to receive(:identifiable).and_return({ a: 1, b: 2})
+      end
+
+      it "should return a comma separated list" do
+        expect(subject.identifier).to eq "a=1, b=2"
+      end
     end
   end
 end

--- a/spec/heroku/properties/null_logger_spec.rb
+++ b/spec/heroku/properties/null_logger_spec.rb
@@ -14,7 +14,7 @@ describe Heroku::Properties::NullLogger do
 
     it { should respond_to(:tagged).with(1).argument }
     it "calls the block provided to it" do
-      block_check.should_receive(:call).once
+      expect(block_check).to receive(:call).once
 
       subject.tagged("tag") do
         block_check.call

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,4 @@
 Bundler.setup
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
 
 require 'heroku_api'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ CodeClimate::TestReporter.start
 require 'heroku_api'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
Fixing the gem to accommodate for changes in Ruby 2.1.1's `Net::HTTP#request` method.

_Fixes are backwards compatible with Ruby 1.9.3_
